### PR TITLE
fix: definition of non-deterministic

### DIFF
--- a/blog/2024-03-05-determinisitic-simulation-testing/index.md
+++ b/blog/2024-03-05-determinisitic-simulation-testing/index.md
@@ -80,7 +80,7 @@ A system is determinitic if for every Initial State σ, the cardinality of the s
 ∀ σ ∈ Σ : | traces(S, σ, R) | = 1
 ```
 
-A system is non-deterministic if for every Initial State σ, the cardinality of the set of traces for System S under Runtime R is larger than 1:
+A system is non-deterministic if there exists an Initial State σ such that the cardinality of the set of traces for System S under Runtime R is larger than 1:
 
 ```
 ∃ σ ∈ Σ : | traces(S, σ, R) | > 1


### PR DESCRIPTION
The English definition uses `for every` language for both `deterministic` and `non-deterministic` whereas the mathematic definition switches from `for every` to `there exists`.

This changes the English definition for `non-deterministic` to match the mathematic definition.