### PR TITLE
Adding google analytics tag to Docusaurus config to test analytics

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,6 +46,10 @@ const config: Config = {
             './static/css/boxicons.min.css'
           ],
         },
+        gtag: {
+          trackingID: 'G-0660YY8LZF',
+          anonymizeIP: true,
+        }
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
This PR adding a gtag config to the docusaurus config so we can test Google analytics.